### PR TITLE
Cleanups, format output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@
     "channel": "#notifications-room, optional defaults to slack defined",
     "message_prefix": "optional prefix - can be used for mentions",
     "surround": "optional - can be used for bold(*), italics(_), code(`) and preformatted(```)",
-    "bot_name": "optional bot name, defaults to slack defined"
+    "bot_name": "optional bot name, defaults to slack defined",
+    "template": "/some/path/to/template.erb",
+    "fields": [
+      "list",
+      "of",
+      "optional",
+      "clientkeys",
+      "to_render"
+    ]
   }
 }
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,31 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = '2'
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = 'chef/centos-6.6'
+  config.vm.box_download_checksum = true
+  config.vm.box_download_checksum_type = 'md5'
+  config.vm.hostname = 'sensu-plugins-dev'
+
+  script = <<EOF
+  sudo yum update -y
+  sudo yum groupinstall -y development
+  sudo yum install -y vim nano
+  #sudo yum install -y ImagicMagic ImageMagick-devel mysql-devel # needed for bundle install
+  gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
+  curl -L get.rvm.io | bash -s stable
+  source /home/vagrant/.rvm/scripts/rvm
+  rvm reload
+  #rvm install 1.9.3
+  rvm install 2.1.4
+  #rvm install 2.0.0
+  #rvm use 1.9.3@sensu_plugins --create
+  #rvm use 2.0.0@sensu_plugins --create
+  rvm use 2.1.4@sensu_plugins --create
+  rvm use 2.1.4@sensu_plugins --default
+EOF
+
+  config.vm.provision 'shell', inline: script, privileged: false
+end

--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -115,9 +115,9 @@ class Slack < Sensu::Handler
         # -vjanelle
         is_short = true unless @event['client'][field].length > 50
         client_fields << {
-          :title => field,
-          :value => @event['client'][field],
-          :short => is_short
+          title: field,
+          value: @event['client'][field],
+          short: is_short
         }
       end
     end

--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -71,14 +71,14 @@ class Slack < Sensu::Handler
     if message_template && File.readable?(message_template)
       template = File.read(message_template)
     else
-      template = """<%=
+      template = '''<%=
       [
-        @event['check']['output'],
-        @event['client']['address'],
-        @event['client']['subscriptions'].join(',')
-      ].join(' : ')
+        @event["check"]["output"],
+        @event["client"]["address"],
+        @event["client"]["subscriptions"].join(",")
+      ].join(" : ")
       %>
-      """
+      '''
     end
     eruby = Erubis::Eruby.new(template)
     eruby.result(binding)

--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -13,6 +13,7 @@
 
 require 'sensu-handler'
 require 'json'
+require 'erubis'
 
 class Slack < Sensu::Handler
   option :json_config,
@@ -26,7 +27,11 @@ class Slack < Sensu::Handler
   end
 
   def slack_channel
-    get_setting('channel')
+    if @event['check']['slack_channel']
+      @event['check']['slack_channel']
+    else
+      get_setting('channel')
+    end
   end
 
   def slack_message_prefix
@@ -39,6 +44,14 @@ class Slack < Sensu::Handler
 
   def slack_surround
     get_setting('surround')
+  end
+
+  def message_template
+    get_setting('template')
+  end
+
+  def fields
+    get_setting('fields')
   end
 
   def incident_key
@@ -55,11 +68,20 @@ class Slack < Sensu::Handler
   end
 
   def build_description
-    [
-      @event['check']['output'],
-      @event['client']['address'],
-      @event['client']['subscriptions'].join(',')
-    ].join(' : ')
+    if message_template && File.readable?(message_template)
+      template = File.read(message_template)
+    else
+      template = """<%=
+      [
+        @event['check']['output'],
+        @event['client']['address'],
+        @event['client']['subscriptions'].join(',')
+      ].join(' : ')
+      %>
+      """
+    end
+    eruby = Erubis::Eruby.new(template)
+    eruby.result(binding)
   end
 
   def post_data(notice)
@@ -85,11 +107,28 @@ class Slack < Sensu::Handler
   end
 
   def payload(notice)
+    client_fields = []
+
+    unless fields.nil?
+      fields.each do |field|
+        # arbritary based on what I feel like
+        # -vjanelle
+        is_short = true unless @event['client'][field].length > 50
+        client_fields << {
+          :title => field,
+          :value => @event['client'][field],
+          :short => is_short
+        }
+      end
+    end
+
     {
       icon_url: 'http://sensuapp.org/img/sensu_logo_large-c92d73db.png',
       attachments: [{
+        title: "#{@event['client']['address']} - #{translate_status}",
         text: [slack_message_prefix, notice].compact.join(' '),
-        color: color
+        color: color,
+        fields: client_fields
       }]
     }.tap do |payload|
       payload[:channel] = slack_channel if slack_channel
@@ -109,5 +148,15 @@ class Slack < Sensu::Handler
 
   def check_status
     @event['check']['status']
+  end
+
+  def translate_status
+    status = {
+      0 => :OK,
+      1 => :WARNING,
+      2 => :CRITICAL,
+      3 => :UNKNOWN
+    }
+    status[check_status.to_i]
   end
 end

--- a/sensu-plugins-slack.gemspec
+++ b/sensu-plugins-slack.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'sensu-plugin',      '1.1.0'
   s.add_runtime_dependency 'json',              '1.8.2'
+  s.add_runtime_dependency 'erubis'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'rubocop',                   '~> 0.30'


### PR DESCRIPTION
Adds the ability for a slack check to say which channel the message should be output to.

Adds configuration options for an erb message template that can be used
to parse / render event data.
* This is added as a configuration entry under the slack token.
* Adds a dependancy to erubis

Adds enumeration of client keys to add as 'fields' in the slack posting
* This is added as an array of entries under 'field' in the slack configuration.
* This arbritarily defines anything < 50 characters as "short" and slack will render them side by side.

Adds a title to the slack message to make things prettier

Helper function to translate status codes to english text.

Updates sensu gem requirements and makes rubocop work

Cleans up warnings that rubocop was making