### PR TITLE
Allow for support of client configuration of channel

### DIFF
--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -27,11 +27,7 @@ class Slack < Sensu::Handler
   end
 
   def slack_channel
-    if @event['check']['slack_channel']
-      @event['check']['slack_channel']
-    else
-      get_setting('channel')
-    end
+    @event['client']['slack_channel'] || @event['check']['slack_channel'] || get_setting('channel')
   end
 
   def slack_message_prefix


### PR DESCRIPTION
For our JIT checks we want to be able to have the channel for slack specified in the check results.