### PR TITLE
ensure field exists in client before calling .length

### DIFF
--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -109,7 +109,7 @@ class Slack < Sensu::Handler
       fields.each do |field|
         # arbritary based on what I feel like
         # -vjanelle
-        is_short = true unless @event['client'][field].length > 50
+        is_short = true unless @event['client'].key?(field) && @event['client'][field].length > 50
         client_fields << {
           title: field,
           value: @event['client'][field],


### PR DESCRIPTION
fixes https://github.com/sensu-plugins/sensu-plugins-slack/issues/6

This just prevents the exception described in https://github.com/sensu-plugins/sensu-plugins-slack/issues/6.  Now, if a field is missing from a client, it sends it as a short field with no value.