### PR TITLE
Modify icon, escape quotes, json data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+### Changed
+- Slack handler posts JSON content type and format to slack.
+- Slack config supports icon_url and icon_emoji
 ### Added
 - add arguments to specify proxy settings
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
     "proxy_port": "The HTTP proxy port (if there is a proxy)"
     "proxy_username": "The HTTP proxy username (if there is a proxy)"
     "proxy_password": "The HTTP proxy user password (if there is a proxy)"
+    "icon_url" : "http://sensuapp.org/img/sensu_logo_large-c92d73db.png"
+    "icon_emoji" : ":snowman:"
     "fields": [
       "list",
       "of",

--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -26,6 +26,10 @@ class Slack < Sensu::Handler
     get_setting('webhook_url')
   end
 
+  def slack_icon_emoji
+    get_setting('icon_emoji')
+  end
+
   def slack_icon_url
     get_setting('icon_url')
   end
@@ -154,6 +158,7 @@ class Slack < Sensu::Handler
     }.tap do |payload|
       payload[:channel] = slack_channel if slack_channel
       payload[:username] = slack_bot_name if slack_bot_name
+      payload[:icon_emoji] = slack_icon_emoji if slack_icon_emoji
     end
   end
 

--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -26,6 +26,10 @@ class Slack < Sensu::Handler
     get_setting('webhook_url')
   end
 
+  def slack_icon_url
+    get_setting('icon_url')
+  end
+
   def slack_channel
     @event['client']['slack_channel'] || @event['check']['slack_channel'] || get_setting('channel')
   end
@@ -85,7 +89,7 @@ class Slack < Sensu::Handler
     else
       template = '''<%=
       [
-        @event["check"]["output"],
+        @event["check"]["output"].gsub(\'"\', \'\\"\'),
         @event["client"]["address"],
         @event["client"]["subscriptions"].join(",")
       ].join(" : ")
@@ -105,9 +109,10 @@ class Slack < Sensu::Handler
            end
     http.use_ssl = true
 
-    req = Net::HTTP::Post.new("#{uri.path}?#{uri.query}")
+    req = Net::HTTP::Post.new("#{uri.path}?#{uri.query}", 'Content-Type' => 'application/json')
     text = slack_surround ? slack_surround + notice + slack_surround : notice
-    req.body = "payload=#{payload(text).to_json}"
+
+    req.body = payload(text).to_json
 
     response = http.request(req)
     verify_response(response)
@@ -139,7 +144,7 @@ class Slack < Sensu::Handler
     end
 
     {
-      icon_url: 'http://sensuapp.org/img/sensu_logo_large-c92d73db.png',
+      icon_url: slack_icon_url ? slack_icon_url : 'http://sensuapp.org/img/sensu_logo_large-c92d73db.png',
       attachments: [{
         title: "#{@event['client']['address']} - #{translate_status}",
         text: [slack_message_prefix, notice].compact.join(' '),


### PR DESCRIPTION
Allow for the modification of the icon.
Escape quotes so the messages are not dropped.
Send data in json format.