### PR TITLE
Switch the Slack message title to reference the client name instead of IP address.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 
+## [0.1.2] - 2016-01-12
+### Changed
+- Switched the Slack message title to reference the client name instead of the client IP address
+
 ## [0.1.1] - 2015-12-09
 ### Changed
 - Slack handler posts JSON content type and format to slack.

--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -150,7 +150,7 @@ class Slack < Sensu::Handler
     {
       icon_url: slack_icon_url ? slack_icon_url : 'http://sensuapp.org/img/sensu_logo_large-c92d73db.png',
       attachments: [{
-        title: "#{@event['client']['address']} - #{translate_status}",
+        title: "#{@event['client']['name']} - #{translate_status}",
         text: [slack_message_prefix, notice].compact.join(' '),
         color: color,
         fields: client_fields

--- a/lib/sensu-plugins-slack/version.rb
+++ b/lib/sensu-plugins-slack/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsSlack
   module Version
     MAJOR = 0
     MINOR = 1
-    PATCH = 1
+    PATCH = 2
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
This makes messages to Slack cleaner and more useful, as the client's name
shows up instead of an IP address.
