### PR TITLE
Added support for sensu playbook custom field

### DIFF
--- a/bin/handler-slack-multichannel.rb
+++ b/bin/handler-slack-multichannel.rb
@@ -132,7 +132,15 @@ class Slack < Sensu::Handler
   end
 
   def build_notice
-    "#{@event['check']['status'].to_s.rjust(3)} | #{incident_key}: #{@event['check']['output'].strip}"
+      # Default string to post on Slack
+      notice_message = "#{@event['check']['status'].to_s.rjust(3)} | #{incident_key}: #{@event['check']['output'].strip}"
+
+      # Append a newline with the check's playbook field if defined
+      if @event['check']['playbook']
+        notice_message = "#{@event['check']['status'].to_s.rjust(3)} | #{incident_key}: #{@event['check']['output'].strip}\n\n#{@event['check']['playbook']}"
+      end
+
+      return notice_message
   end
 
   def handle


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues


This change will add the playbook field as part of the message sent into
the slack channels.This playbook field would contain a URL for
documentation to aid in the resolution of events for the check.

I want to stick with the playbook name since i expect many users to just
use this name by default after reading the following documentation found
on the official sensu website:

https://sensuapp.org/docs/latest/checks#example

The handler-mailer already supports this custom definition attribute:

https://github.com/sensu-plugins/sensu-plugins-mailer/blob/master/bin/handler-mailer.rb#L145