### PR TITLE
Access the event notification in its correct location.

### DIFF
--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -88,7 +88,7 @@ class Slack < Sensu::Handler
 
   def handle
     if payload_template.nil?
-      description = @event['notification'] || build_description
+      description = @event['check']['notification'] || build_description
       post_data("#{incident_key}: #{description}")
     else
       post_data(render_payload_template)


### PR DESCRIPTION
In [`bin/hander-slack.rb`, line 91](https://github.com/sensu-plugins/sensu-plugins-slack/blob/master/bin/handler-slack.rb#L91), the 'notification' key is sought at the root of the event Hash (stored in `@event`).

While I couldn't find any clear documentation for where this key should be located, both the `check-process` and the `check-mtime` plugins put it under `@event['check']`, rather than directly at the root.

Due to this discrepancy, the `Slack` handler ignores the notification provided.

This minimal PR fixes this issue.