### PR TITLE
Fix channel specified when using custom payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Fixed
+- Allow custom channels with custom payload
+
 ## [1.0.1] - 2016-08-08
 ### Added
 - Added a link_names to allow for a mentions

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 {
   "username": "sensu alarms",
   "icon_emoji": ":bell:",
+  "channel": channel,
   "attachments": [
     {
       "fallback": "<%= @event["check"]["output"] %>",

--- a/bin/handler-slack-multichannel.rb
+++ b/bin/handler-slack-multichannel.rb
@@ -157,12 +157,12 @@ class Slack < Sensu::Handler
         notice = @event['notification'] || build_description
         post_data(notice, channel)
       else
-        post_data(render_payload_template, channel)
+        post_data(render_payload_template(channel), channel)
       end
     end
   end
 
-  def render_payload_template
+  def render_payload_template(channel)
     return unless payload_template && File.readable?(payload_template)
     template = File.read(payload_template)
     eruby = Erubis::Eruby.new(template)

--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -95,11 +95,11 @@ class Slack < Sensu::Handler
       description = @event['check']['notification'] || build_description
       post_data("#{incident_key}: #{description}")
     else
-      post_data(render_payload_template)
+      post_data(render_payload_template(slack_channel))
     end
   end
 
-  def render_payload_template
+  def render_payload_template(channel)
     return unless payload_template && File.readable?(payload_template)
     template = File.read(payload_template)
     eruby = Erubis::Eruby.new(template)


### PR DESCRIPTION
When using custom payloads the `channel` setting was not available, so only the default channel could be used.

## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

