### PR TITLE
Adding title line in multichannel payload template 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Added
+
+- Added title line to slack-handler-multichannel.rb to mirror functionality of slack-handler.rb
+
+
+## [1.0.2] - 2017-03-13
 ### Fixed
 - Allow custom channels with custom payload
 

--- a/bin/handler-slack-multichannel.rb
+++ b/bin/handler-slack-multichannel.rb
@@ -230,6 +230,7 @@ class Slack < Sensu::Handler
     {
       icon_url: 'http://sensuapp.org/img/sensu_logo_large-c92d73db.png',
       attachments: [{
+        title: "#{@event['client']['address']} - #{translate_status}",
         text: [slack_message_prefix, notice].compact.join(' '),
         color: color
       }]


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

This change copies the 'title' line of the payload_template configuration in the slack-handler.rb into the slack-handler-multichannel.rb to align the output of both handlers. 

#### Known Compatablity Issues
N/A
