### PR TITLE
Https and fix image links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- Ran rubocop against `bin/slack-handler.rb` and `bin/slack-handler-multichannel.rb` (@pgporada)
+- Fixed occurrences of http:// needing to be https:// by default (@pgporada)
+- Fixed the location of the Sensu image that gets pulled in (@pgporada)
 
 ## [1.1.0] - 2017-06-22
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Sensu-Plugins-slack
 
 [![Build Status](https://travis-ci.org/sensu-plugins/sensu-plugins-slack.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-slack)
-[![Gem Version](https://badge.fury.io/rb/sensu-plugins-slack.svg)](http://badge.fury.io/rb/sensu-plugins-slack)
+[![Gem Version](https://badge.fury.io/rb/sensu-plugins-slack.svg)](https://badge.fury.io/rb/sensu-plugins-slack)
 [![Code Climate](https://codeclimate.com/github/sensu-plugins/sensu-plugins-slack/badges/gpa.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-slack)
 [![Test Coverage](https://codeclimate.com/github/sensu-plugins/sensu-plugins-slack/badges/coverage.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-slack)
 [![Dependency Status](https://gemnasium.com/sensu-plugins/sensu-plugins-slack.svg)](https://gemnasium.com/sensu-plugins/sensu-plugins-slack)
@@ -29,7 +29,7 @@
     "proxy_port": "The HTTP proxy port (if there is a proxy)",
     "proxy_username": "The HTTP proxy username (if there is a proxy)",
     "proxy_password": "The HTTP proxy user password (if there is a proxy)",
-    "icon_url": "http://sensuapp.org/img/sensu_logo_large-c92d73db.png",
+    "icon_url": "https://raw.githubusercontent.com/sensu/sensu-logo/master/sensu1_flat%20white%20bg_png.png",
     "icon_emoji": ":snowman:",
     "fields": [
       "list",
@@ -44,7 +44,7 @@
 
 ## Installation
 
-[Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
+[Installation and Setup](https://sensu-plugins.io/docs/installation_instructions.html)
 
 ## Notes
 

--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -107,18 +107,18 @@ class Slack < Sensu::Handler
   end
 
   def build_description
-    if message_template && File.readable?(message_template)
-      template = File.read(message_template)
-    else
-      template = '''<%=
-      [
-        @event["check"]["output"].gsub(\'"\', \'\\"\'),
-        @event["client"]["address"],
-        @event["client"]["subscriptions"].join(",")
-      ].join(" : ")
-      %>
-      '''
-    end
+    template = if message_template && File.readable?(message_template)
+                 File.read(message_template)
+               else
+                 '''<%=
+                 [
+                   @event["check"]["output"].gsub(\'"\', \'\\"\'),
+                   @event["client"]["address"],
+                   @event["client"]["subscriptions"].join(",")
+                 ].join(" : ")
+                 %>
+                 '''
+               end
     eruby = Erubis::Eruby.new(template)
     eruby.result(binding)
   end
@@ -171,7 +171,7 @@ class Slack < Sensu::Handler
     end
 
     {
-      icon_url: slack_icon_url ? slack_icon_url : 'http://sensuapp.org/img/sensu_logo_large-c92d73db.png',
+      icon_url: slack_icon_url ? slack_icon_url : 'https://raw.githubusercontent.com/sensu/sensu-logo/master/sensu1_flat%20white%20bg_png.png',
       attachments: [{
         title: "#{@event['client']['address']} - #{translate_status}",
         text: [slack_message_prefix, notice].compact.join(' '),


### PR DESCRIPTION
## Pull Request Checklist

Yes, https://github.com/sensu-plugins/sensu-plugins-slack/issues/39

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [X] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

The url for the icon not longer exists. Changed some links to be https:// by default to save on a round trip. Ran rubocop.

#### Known Compatablity Issues

