### PR TITLE
added custom_field documentation and configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - ruby 2.4 testing in travis (@majormoses)
+- `slack-handler-multichannel.rb`: Add custom_field options to supply additional fields (@justbkuz)
 
 ## [1.1.1] - 2017-06-24
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
  * bin/handler-slack.rb
  * bin/handler-slack-multichannel.rb
 
-## Usage
+## Usage for handler-slack.rb
 ```
 {
   "slack": {
@@ -41,6 +41,39 @@
   }
 }
 ```
+## Usage for handler-slack-multichannel.rb
+```
+{
+  "slack": {
+    "webhook_url": "webhook url",
+    "channel": {
+      "default": [ "#no-team-alerts" ],
+      "compulsory": [ "#all-alerts" ]
+    }
+    "message_prefix": "optional prefix - can be used for mentions",
+    "surround": "optional - can be used for bold(*), italics(_), code(`) and preformatted(```)",
+    "bot_name": "optional bot name, defaults to slack defined",
+    "link_names": "optional - find and link channel names and usernames",
+    "message_template": "optional description erb template file - /some/path/to/template.erb",
+    "payload_template": "optional json payload template file (note: overrides most other template options.)",
+    "template": "backwards-compatible alias for message_template",
+    "proxy_address": "The HTTP proxy address (example: proxy.example.com)",
+    "proxy_port": "The HTTP proxy port (if there is a proxy)",
+    "proxy_username": "The HTTP proxy username (if there is a proxy)",
+    "proxy_password": "The HTTP proxy user password (if there is a proxy)",
+    "icon_url": "https://raw.githubusercontent.com/sensu/sensu-logo/master/sensu1_flat%20white%20bg_png.png",
+    "icon_emoji": ":snowman:",
+    "custom_field": [
+      "list",
+      "of",
+      "optional",
+      "check_fields",
+      "to_render"
+    ]
+  }
+}
+```
+
 
 ## Installation
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ √] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [√ ] Update README with any necessary configuration snippets

- [√ ] Binstubs are created if needed

- [√ ] RuboCop passes

- [√ ] Existing tests pass 

#### Purpose
Add the ability to add custom fields to the messages that are sent to slack. fields added that don't exist or have no value are ignored.

![image](https://user-images.githubusercontent.com/30054677/28138084-846a9cc0-671d-11e7-8cee-d8f620fcc63d.png)

#### Known Compatablity Issues

