### PR TITLE
Add client-defined channels support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- `slack-handler-multichannel.rb`: Added support for client-defined channel overrides (@fildred13)
 
 ## [1.3.0] - 2017-07-19
 ### Added

--- a/bin/handler-slack-multichannel.rb
+++ b/bin/handler-slack-multichannel.rb
@@ -33,7 +33,7 @@
 # in the client config or check config.
 #
 # If channels are defined on the client, they will override the defaults:
-# 
+#
 # { "client":{
 #     "name": "Appserver"
 #     "slack" {


### PR DESCRIPTION
I did this work for my organization, so I figured I would offer it here, in case it is something that you want to integrate into the project. I'm willing to make edits, if you want. Hopefully I did the PR correctly this time :)

## Pull Request Checklist

**Is this in reference to an existing issue?**
No.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [na] Update README with any necessary configuration snippets

- [na] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
At least for my organization, we often want clients to be the category against which we determine where to send Slack alerts - only rarely do we use the checks themselves as overrides. This optional feature allows a three-level override: check-defined channels override client-defined channels override default channels.

#### Known Compatablity Issues
None. Full backwards compatibility, since no one would have been defining client-defined channels before this point.
