### PR TITLE
Bump dependency of `sensu-plugin` to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Breaking Changes
+- bumped `sensu-plugin` dependency to 2.x which removes in handler filtering for `occurrences`. If you want to keep using the same filtering features you must specify it and ensure that you have applied the filter by setting `"filters": ["occurrences"]`. For more information see [here](https://blog.sensuapp.org/deprecating-event-filtering-in-sensu-plugin-b60c7c500be3) (@majormoses)
+
 ## [2.0.0] - 2017-10-21
 ### Breaking Changes
 - `handler-slack-multichannel.rb`: Fixed title unknown issue when using proxy clients, change from client address to client name (@autumnw)

--- a/sensu-plugins-slack.gemspec
+++ b/sensu-plugins-slack.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsSlack::Version::VER_STRING
 
   s.add_runtime_dependency 'erubis',         '2.7.0'
-  s.add_runtime_dependency 'sensu-plugin',   '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin',   '~> 2.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
This is a breaking change, to keep filtering of occurences it requires you to add `occurences` to the list of filters associated with the handler.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

- #52 
- https://github.com/sensu-plugins/community/issues/26

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose
Disabling built in occurences, accidentally fixes #52 
#### Known Compatablity Issues
Anyone who was previously using the occurences attribute needs to specify that this handler should use the `occurences` filter.
