### PR TITLE
Added check return value of 127 and a default color for other values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- Fixed unknown sensu check return value 127
+
+### Changed
+- Added default color for unknown sensu check return values
 
 ## [3.0.0] - 2018-01-11
 ### Breaking Changes

--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -199,9 +199,10 @@ class Slack < Sensu::Handler
       0 => '#36a64f',
       1 => '#FFCC00',
       2 => '#FF0000',
-      3 => '#6600CC'
+      3 => '#6600CC',
+      127 => '#6600CC'
     }
-    color.fetch(check_status.to_i)
+    color.fetch(check_status.to_i, '#d13650')
   end
 
   def check_status
@@ -213,7 +214,8 @@ class Slack < Sensu::Handler
       0 => :OK,
       1 => :WARNING,
       2 => :CRITICAL,
-      3 => :UNKNOWN
+      3 => :UNKNOWN,
+      127 => :UNKNOWN
     }
     status[check_status.to_i]
   end


### PR DESCRIPTION
## Pull Request Checklist

#34  Problem with "127" (Unknown) exit codes

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
