### PR TITLE
fix handler-slack.rb by rescuing non specification compliant status codes as `unknown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Fixed
+- handler-slack.rb: rescue any non sensu specification compliant status code passed to the slack handler as the color matching unknown (@majormoses)
+
 ## [3.1.0] - 2018-01-31
 ### Changed
 - `handler-slack.rb`: emit an `unknown` with helpful debug messages when passing in bad config (@majormoses)


### PR DESCRIPTION


Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist
fixes #34 was based off #61 but far more flexible

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass


#### Purpose
Fixes #34 as well as any other non spec compliant status codes

#### Known Compatibility Issues
None
