### PR TITLE
Unify multichannel handler to use client custom fields

### DIFF
--- a/bin/handler-slack-multichannel.rb
+++ b/bin/handler-slack-multichannel.rb
@@ -69,14 +69,6 @@
 #         ]
 #        }
 #
-# On your check.json
-#
-# {
-#   "checks": {
-#     "check_disk_usage": {
-#        "command": " ~/check-disk-usage.rb -w 90 -c 95",
-#        "field_name": "https://someurl.somewhere",
-#        "field_name_2: "something_you_want_added"
 
 require 'sensu-handler'
 require 'json'
@@ -290,10 +282,10 @@ class Slack < Sensu::Handler
     unless custom_field.nil?
       custom_field.each do |field|
         is_short = true unless @event['client'].key?(field) && @event['client'][field].length > 50
-        field_title = field unless @event['check'][field].nil?
+        field_title = field unless @event['client'][field].nil?
         client_fields << {
           title: field_title,
-          value: @event['check'][field],
+          value: @event['client'][field],
           short: is_short
         }
       end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No
#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass


#### Purpose
 - Include custom **client** field in the payload as in the handler-slack.rb handler
 - It seems that this was also the original intention, otherwise it makes no sense to check the **client's** fields length ( [line 292](https://github.com/sensu-plugins/sensu-plugins-slack/blob/master/bin/handler-slack-multichannel.rb#L292) )
