### PR TITLE
Pass plain text in order to trigger mention notifications (needed by mattermost)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ### Fixed
 - handler-slack-multichannel.rb: updated the comments to be valid json as they were missing `:` for keys (@lcx)
 
+### Fixed
+- `handler-slack.rb` and `handler-slack-multichannel.rb`: Pass plain text in order to support mention notifications in Mattermost (@joostfaassen)
+
+
 ## [3.1.1] - 2018-03-17
 ### Fixed
 - handler-slack.rb: rescue any non sensu specification compliant status code passed to the slack handler as the color matching unknown (@majormoses)

--- a/bin/handler-slack-multichannel.rb
+++ b/bin/handler-slack-multichannel.rb
@@ -300,6 +300,7 @@ class Slack < Sensu::Handler
     end
     {
       icon_url: slack_icon_url ? slack_icon_url : 'https://raw.githubusercontent.com/sensu/sensu-logo/master/sensu1_flat%20white%20bg_png.png',
+      text: [slack_message_prefix, notice].compact.join(' '),
       attachments: [{
         title: "#{@event['client']['name']} - #{translate_status}",
         text: [slack_message_prefix, notice].compact.join(' '),

--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -189,6 +189,7 @@ class Slack < Sensu::Handler
 
     {
       icon_url: slack_icon_url ? slack_icon_url : 'https://raw.githubusercontent.com/sensu/sensu-logo/master/sensu1_flat%20white%20bg_png.png',
+      text: [slack_message_prefix, notice].compact.join(' '),
       attachments: [{
         title: "#{@event['client']['address']} - #{translate_status}",
         text: [slack_message_prefix, notice].compact.join(' '),


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [*] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

#### Purpose

The `@mention` notation only triggers notifications to users if it is sent via the `text` attribute, not when it's nested in the `attachments` attribute.
