### PR TITLE
handler-slack.rb: implement a retry-timeout strategy for contacting s…

### DIFF
--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -204,7 +204,6 @@ class Slack < Sensu::Handler
         exit 1
       end
     end # of retries loop
-
   end # of post_data
 
   def payload(notice)

--- a/bin/handler-slack.rb
+++ b/bin/handler-slack.rb
@@ -168,7 +168,6 @@ class Slack < Sensu::Handler
     begin # retries loop
       tries = slack_webhook_retries
       Timeout.timeout(slack_webhook_timeout) do
-
         begin # main loop for trying to deliver the message to slack webhook
           req = Net::HTTP::Post.new("#{uri.path}?#{uri.query}", 'Content-Type' => 'application/json')
 
@@ -179,7 +178,7 @@ class Slack < Sensu::Handler
             req.body = body
           end
 
-          response = http.request(req)
+          http.request(req)
 
         # replace verify_response with a rescue within the loop
         rescue Net::HTTPServerException => error
@@ -189,13 +188,11 @@ class Slack < Sensu::Handler
             retry
           else
             # raise error for sensu-server to catch and log
-            puts 'slack api failed (retries) ' + incident_key + ' : ' + error.response.code + ' ' + error.response.message + ': sending to channel "' + slack_channel + '" the message: ' + body
+            puts "slack api failed (retries) #{incident_key}: #{error.response.code} #{error.response.message}: channel '#{slack_channel}', message: #{body}"
             exit 1
           end
         end # of main loop for trying to deliver the message to slack webhook
-
       end # of timeout:do loop
-
     # if the timeout is exceeded, consider this try failed
     rescue Timeout::Error
       if (tries -= 1) > 0
@@ -203,7 +200,7 @@ class Slack < Sensu::Handler
         retry
       else
         # raise error for sensu-server to catch and log
-        puts 'slack webhook failed (timeout) ' + incident_key + ' : sending to channel "' + slack_channel + '" the message: ' + body
+        puts "slack webhook failed (timeout) #{incident_key}: channel '#{slack_channel}', message: #{body}"
         exit 1
       end
     end # of retries loop


### PR DESCRIPTION
…lack webhook

In certain scenarios the slack webhook delivery might fail due to several reasons:
- network issues
- rate limit exceeded
- internal server errors on slack api side

On those cases the call to the webhook might fail and our message not get delivered, or worse, it can leave our handler hanging for too long.

This commit implements a customizable retry strategy that tries to deliver the message several times to the webhook, with a timeout to do so. It also implements a sleep time in between retries.
All of these 3 settings can be customized in the json config of the handler, with defaults to 5 retries with 5 second sleeps in between, and 10 seconds timeout for each try.

This should incidentally solve issue #15

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
