### PR TITLE
Enable default webhook in multichannel handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+## [4.2.0]- 2019-10-08
+### Added
+- `handler-slack-multichannel.rb`: Added a conditional that enables sending to a default webhook if the provided channels do not have their own dedicated webhook. 
+
 ## [4.1.0]- 2019-05-16
 ### Added
 - `handler-slack`: added `webhook_retries` (default: 5), `webhook_timeout` (default: 10), and `webhook_retry_sleep` configuration properties to harden against failures due to networking, rate limits, etc. (@kali-brandwatch)

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@
 {
   "slack": {
     "webhook_urls": {
-      "no-team-alerts": "https://hooks.slack.com/services/AAAAAAA",
-      "all-alerts": "https://hooks.slack.com/services/BBBBBB"
+      "default": "https://hooks.slack.com/services/AAAAAAA"
+      "no-team-alerts": "https://hooks.slack.com/services/BBBBBB",
+      "all-alerts": "https://hooks.slack.com/services/CCCCCC"
     },
     "channels": {
       "default": [ "no-team-alerts" ],

--- a/bin/handler-slack-multichannel.rb
+++ b/bin/handler-slack-multichannel.rb
@@ -244,7 +244,12 @@ class Slack < Sensu::Handler
   end
 
   def post_data(notice, channel)
-    slack_webhook_url = webhook_urls[channel]
+    if webhook_urls[channel].nil?
+      slack_webhook_url = webhook_urls['default']
+    else 
+      slack_webhook_url = webhook_urls[channel]
+    end
+
     uri = URI(slack_webhook_url)
 
     http = if defined?(slack_proxy_addr).nil?


### PR DESCRIPTION
#### Purpose
 
This PR adds the ability to set a default webhook url in the multichannel handler. If a channel does not have a dedicated webhook, the default one will be used to send messages. 

